### PR TITLE
Add simple cli script with wrapper of main function

### DIFF
--- a/osm2geojson-lite
+++ b/osm2geojson-lite
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const osm2geojson = require('./lib/index.js');
+
+const data = fs.readFileSync("/dev/stdin", "utf-8");
+
+const geojson = osm2geojson(data, {});
+
+process.stdout.write(JSON.stringify(geojson));

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "/"
   ],
   "author": "tibetty",
+  "bin": {
+    "osm2geojson-lite": "osm2geojson-lite"
+  },
   "bugs": {
     "url": "https://github.com/tibetty/osm2geojson-lite/issues"
   },


### PR DESCRIPTION
Original [tyrasd/osmtogeojson](https://github.com/tyrasd/osmtogeojson) library contains command-line script [osmtogeojson](https://github.com/tyrasd/osmtogeojson/blob/gh-pages/osmtogeojson) that allows make a conversion in command line like this:
```bash
cat osm.json | osmtogeojson
```
Will be good to have same tool in your `osm2geojson-lite` package too.
I've added the simple `osm2geojson-lite` js script that gets data from stdin and outputs GeoJSON result to stdout, usage is same:
```bash
cat osm.json | osm2geojson-lite
```

In future it can be extended by command line options and other features, but at first step - simple script is better than nothing.

Please review it.