### PR TITLE
Add browserify and uglify-js as dev dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 osm2geojson-lite.js: lib/index.js package.json
-	browserify -s osm2geojson lib/index.js | uglifyjs -c -m -o dist/osm2geojson-lite.js
+	npx browserify -s osm2geojson lib/index.js | npx uglifyjs -c -m -o dist/osm2geojson-lite.js

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "lib": "lib",
     "test": "test"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "browserify": "^17.0.0",
+    "uglify-js": "^3.14.5"
+  }
 }


### PR DESCRIPTION
Instead of relying of globally installed browserify and uglify-js, add them to the dev dependencies and use use `npx` in the Makefile.